### PR TITLE
Updates to item versioning

### DIFF
--- a/src/graph_client.py
+++ b/src/graph_client.py
@@ -47,8 +47,6 @@ class GraphClient:
         with open(f"{self.data_path}/{key}.json") as file:
             document = Document.parse_obj(json.load(file))
 
-        document.abstract = self.keyword_client.highlight_keywords(document.abstract)
-
         template = self.env.get_template('document_page_template.md')
         annotations = self.get_document_annotations(document)
 

--- a/src/keyword_client.py
+++ b/src/keyword_client.py
@@ -32,8 +32,6 @@ class KeywordClient:
             document = Document.model_validate(json.load(file))
         
         corpus = []
-        if document.abstract:
-            corpus.append(document.abstract)
         
         for note in document.notes:
             corpus.append(note.text)

--- a/templates/document_page_template.md
+++ b/templates/document_page_template.md
@@ -1,6 +1,5 @@
 type:: Document
 key:: {{ document.key }}
-abstract:: {% if document.abstract %}{{ document.abstract }}{% endif %}
 
 {% for annotation in annotations %}
 {% if annotation.type == "note" %}


### PR DESCRIPTION
Added item versions for annotations and notes. Now need to update the `DocumentClient.sync_document` method to support updating documents anytime there is a change to a document or its children. 

While I'm at it - I can add support for removing items that have been removed from Zotero #9, and remove abstracts #17.